### PR TITLE
Downgrade Tensorflow to 2.3.2

### DIFF
--- a/images/cern-root/Dockerfile
+++ b/images/cern-root/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.4.1-gpu
+FROM tensorflow/tensorflow:2.3.2-gpu
 
 
 LABEL maintainer "Joao Victor da Fonseca Pinto <jodafons@lps.ufrj.br>"


### PR DESCRIPTION
According to [this source](https://www.tensorflow.org/install/source#tested_build_configurations), Tensorflow 2.4.x is compatible with CUDA 11.0 but, in our cluster, all machines support CUDA 10.2 and 10.1 only. In that case, downgrading to 2.3.2 should fix any issue.